### PR TITLE
disable pages publish - wasm menu not closing

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -3,8 +3,8 @@ name: Deploy to Pages
 
 on:
   # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
+  # push:
+  #   branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
- the menu in wasm mode will not close due to some issue building with Go 1.20 or recent versions of ebitengine where it is not properly capturing mouse from browser when instructed to
